### PR TITLE
[DM-28130] Fix matching for Kubernetes Service

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
   - name: "lsstsqre/safirdemo"
-    newTag: 1.0.0
+    newTag: 1.0.1
 
 resources:
   - configmap.yaml

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -11,4 +11,4 @@ spec:
       port: 8080
       targetPort: "app"
   selector:
-    name: "safirdemo"
+    app.kubernetes.io/name: "safirdemo"


### PR DESCRIPTION
We switched from name to the recommended app.kubernetes.io/name
and didn't update the matching logic in the Service.  Update that.