### PR TITLE
[DM-30907] Fix version number in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,3 @@
-# Some additional things to ignore beyond what .gitignore already handles.
-# We cannot exclude the .git directory because setuptools_scm requires it.
-tests/
-
 # Everything below this point is a copy of .gitignore.
 
 # Byte-compiled / optimized / DLL files

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Define the Docker tag
         id: vars

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,9 @@ FROM dependencies-image AS install-image
 # Use the virtualenv
 ENV PATH="/opt/venv/bin:$PATH"
 
-COPY . /app
-WORKDIR /app
+COPY . /workdir
+WORKDIR /workdir
+RUN git status
 RUN pip install --no-cache-dir .
 
 FROM base-image AS runtime-image

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -304,7 +304,7 @@ typing-extensions==3.10.0.0 \
     # via
     #   -c requirements/main.txt
     #   mypy
-uvicorn[standard]==0.14.0 \
+uvicorn==0.14.0 \
     --hash=sha256:2a76bb359171a504b3d1c853409af3adbfa5cef374a4a59e5881945a97a93eae \
     --hash=sha256:45ad7dfaaa7d55cab4cd1e85e03f27e9d60bc067ddc59db52a2b0aeca8870292
     # via


### PR DESCRIPTION
For setuptools_scm to generate the correct version number, the
checkout has to be clean, match the latest tag, and not have any
stray uncommitted files.  We were picking up stray files because
the FastAPI image installs some by default in /app, which we were
using as a working directory.  We were also excluding tests from
the Docker image, which made the checkout dirty.  And we weren't
checking out the full repository with tags so setuptools_scm didn't
see the tags.

Fix all of this by fetching the full repository, changing the
working directory, and removing tests/ from .dockerignore.