### PR TITLE
[DM-31438] Refresh from the current template

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
 
@@ -42,7 +41,7 @@ jobs:
 
       - name: Cache tox environments
         id: cache-tox
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .tox
           # requirements/*.txt and pyproject.toml have versioning info
@@ -83,33 +82,26 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys:
-            ${{ runner.os }}-buildx-
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
-          tags: lsstsqre/safirdemo:${{ steps.vars.outputs.tag }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          tags: |
+            lsstsqre/safirdemo:${{ steps.vars.outputs.tag }}
+            ghcr.io/lsst-sqre/safirdemo:${{ steps.vars.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ init:
 	pip install --editable .
 	pip install --upgrade -r requirements/main.txt -r requirements/dev.txt
 	rm -rf .tox
-	pip install --upgrade tox
+	pip install --upgrade pre-commit tox
 	pre-commit install
 
 .PHONY: update

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: app
           imagePullPolicy: "IfNotPresent"
           # Use images field in a Kustomization to set/update image tag
-          image: "lsstsqre/safirdemo"
+          image: "ghcr.io/lsst-sqre/safirdemo"
           ports:
             - containerPort: 8080
               name: "app"

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 images:
-  - name: "lsstsqre/safirdemo"
-    newTag: 1.0.2
+  - name: "ghcr.io/lsst-sqre/safirdemo"
+    newTag: 1.1.0
 
 resources:
   - configmap.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,18 @@ include_trailing_comma = true
 multi_line_output = 3
 known_first_party = ["safirdemo", "tests"]
 skip = ["docs/conf.py"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+# The python_files setting is not for test detection (pytest will pick up any
+# test files named *_test.py without this setting) but to enable special
+# assert processing in any non-test supporting files under tests.  We
+# conventionally put test support functions under tests.support and may
+# sometimes use assert in test fixtures in conftest.py, and pytest only
+# enables magical assert processing (showing a full diff on assert failures
+# with complex data structures rather than only the assert message) in files
+# listed in python_files.
+python_files = [
+    "tests/*.py",
+    "tests/*/*.py"
+]

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -15,4 +15,3 @@ pre-commit
 pytest
 pytest-asyncio
 pytest-cov
-uvicorn

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,17 +10,10 @@ anyio==3.5.0 \
     # via
     #   -c requirements/main.txt
     #   httpcore
-    #   watchgod
 asgi-lifespan==1.0.1 \
     --hash=sha256:9a33e7da2073c4764bc79bd6136501d6c42f60e3d2168ba71235e84122eadb7f \
     --hash=sha256:9ea969dc5eb5cf08e52c08dce6f61afcadd28112e72d81c972b1d8eb8691ab53
     # via -r requirements/dev.in
-asgiref==3.5.0 \
-    --hash=sha256:2f8abc20f7248433085eda803936d98992f1343ddb022065779f37c5da0181d0 \
-    --hash=sha256:88d59c13d634dcffe0510be048210188edd79aeccb6a6c9028cdad6f31d730a9
-    # via
-    #   -c requirements/main.txt
-    #   uvicorn
 attrs==21.4.0 \
     --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
     --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
@@ -42,12 +35,6 @@ charset-normalizer==2.0.12 \
     # via
     #   -c requirements/main.txt
     #   httpx
-click==8.0.4 \
-    --hash=sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1 \
-    --hash=sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb
-    # via
-    #   -c requirements/main.txt
-    #   uvicorn
 coverage[toml]==6.3.2 \
     --hash=sha256:03e2a7826086b91ef345ff18742ee9fc47a6839ccd517061ef8fa1976e652ce9 \
     --hash=sha256:07e6db90cd9686c767dcc593dff16c8c09f9814f5e9c51034066cad3373b914d \
@@ -107,51 +94,12 @@ h11==0.12.0 \
     # via
     #   -c requirements/main.txt
     #   httpcore
-    #   uvicorn
 httpcore==0.14.7 \
     --hash=sha256:47d772f754359e56dd9d892d9593b6f9870a37aeb8ba51e9a88b09b3d68cfade \
     --hash=sha256:7503ec1c0f559066e7e39bc4003fd2ce023d01cf51793e3c173b864eb456ead1
     # via
     #   -c requirements/main.txt
     #   httpx
-httptools==0.4.0 \
-    --hash=sha256:1a99346ebcb801b213c591540837340bdf6fd060a8687518d01c607d338b7424 \
-    --hash=sha256:1ee0b459257e222b878a6c09ccf233957d3a4dcb883b0847640af98d2d9aac23 \
-    --hash=sha256:20a45bcf22452a10fa8d58b7dbdb474381f6946bf5b8933e3662d572bc61bae4 \
-    --hash=sha256:29bf97a5c532da9c7a04de2c7a9c31d1d54f3abd65a464119b680206bbbb1055 \
-    --hash=sha256:2c9a930c378b3d15d6b695fb95ebcff81a7395b4f9775c4f10a076beb0b2c1ff \
-    --hash=sha256:2db44a0b294d317199e9f80123e72c6b005c55b625b57fae36de68670090fa48 \
-    --hash=sha256:3194f6d6443befa8d4db16c1946b2fc428a3ceb8ab32eb6f09a59f86104dc1a0 \
-    --hash=sha256:34d2903dd2a3dd85d33705b6fde40bf91fc44411661283763fd0746723963c83 \
-    --hash=sha256:48e48530d9b995a84d1d89ae6b3ec4e59ea7d494b150ac3bbc5e2ac4acce92cd \
-    --hash=sha256:54bbd295f031b866b9799dd39cb45deee81aca036c9bff9f58ca06726f6494f1 \
-    --hash=sha256:5d1fe6b6661022fd6cac541f54a4237496b246e6f1c0a6b41998ee08a1135afe \
-    --hash=sha256:645373c070080e632480a3d251d892cb795be3d3a15f86975d0f1aca56fd230d \
-    --hash=sha256:6a1a7dfc1f9c78a833e2c4904757a0f47ce25d08634dd2a52af394eefe5f9777 \
-    --hash=sha256:701e66b59dd21a32a274771238025d58db7e2b6ecebbab64ceff51b8e31527ae \
-    --hash=sha256:72aa3fbe636b16d22e04b5a9d24711b043495e0ecfe58080addf23a1a37f3409 \
-    --hash=sha256:7af6bdbd21a2a25d6784f6d67f44f5df33ef39b6159543b9f9064d365c01f919 \
-    --hash=sha256:7ee9f226acab9085037582c059d66769862706e8e8cd2340470ceb8b3850873d \
-    --hash=sha256:7f7bfb74718f52d5ed47d608d507bf66d3bc01d4a8b3e6dd7134daaae129357b \
-    --hash=sha256:8e2eb957787cbb614a0f006bfc5798ff1d90ac7c4dd24854c84edbdc8c02369e \
-    --hash=sha256:903f739c9fb78dab8970b0f3ea51f21955b24b45afa77b22ff0e172fc11ef111 \
-    --hash=sha256:98993805f1e3cdb53de4eed02b55dcc953cdf017ba7bbb2fd89226c086a6d855 \
-    --hash=sha256:9967d9758df505975913304c434cb9ab21e2c609ad859eb921f2f615a038c8de \
-    --hash=sha256:a113789e53ac1fa26edf99856a61e4c493868e125ae0dd6354cf518948fbbd5c \
-    --hash=sha256:a522d12e2ddbc2e91842ffb454a1aeb0d47607972c7d8fc88bd0838d97fb8a2a \
-    --hash=sha256:abe829275cdd4174b4c4e65ad718715d449e308d59793bf3a931ee1bf7e7b86c \
-    --hash=sha256:c286985b5e194ca0ebb2908d71464b9be8f17cc66d6d3e330e8d5407248f56ad \
-    --hash=sha256:cd1295f52971097f757edfbfce827b6dbbfb0f7a74901ee7d4933dff5ad4c9af \
-    --hash=sha256:ceafd5e960b39c7e0d160a1936b68eb87c5e79b3979d66e774f0c77d4d8faaed \
-    --hash=sha256:d1f27bb0f75bef722d6e22dc609612bfa2f994541621cd2163f8c943b6463dfe \
-    --hash=sha256:d3a4e165ca6204f34856b765d515d558dc84f1352033b8721e8d06c3e44930c3 \
-    --hash=sha256:d9b90bf58f3ba04e60321a23a8723a1ff2a9377502535e70495e5ada8e6e6722 \
-    --hash=sha256:f72b5d24d6730035128b238decdc4c0f2104b7056a7ca55cf047c106842ec890 \
-    --hash=sha256:fcddfe70553be717d9745990dfdb194e22ee0f60eb8f48c0794e7bfeda30d2d5 \
-    --hash=sha256:fdb9f9ed79bc6f46b021b3319184699ba1a22410a82204e6e89c774530069683
-    # via
-    #   -c requirements/main.txt
-    #   uvicorn
 httpx==0.22.0 \
     --hash=sha256:d8e778f76d9bbd46af49e7f062467e3157a5a3d2ae4876a4bbfd8a51ed9c9cb4 \
     --hash=sha256:e35e83d1d2b9b2a609ef367cc4c1e66fd80b750348b20cc9e19d1952fc2ca3f6
@@ -245,12 +193,6 @@ pytest-cov==3.0.0 \
     --hash=sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6 \
     --hash=sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470
     # via -r requirements/dev.in
-python-dotenv==0.19.2 \
-    --hash=sha256:32b2bdc1873fd3a3c346da1c6db83d0053c3c62f28f1f38516070c4c8971b1d3 \
-    --hash=sha256:a5de49a31e953b45ff2d2fd434bbc2670e8db5273606c1e737cc6b93eff3655f
-    # via
-    #   -c requirements/main.txt
-    #   uvicorn
 pyyaml==6.0 \
     --hash=sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293 \
     --hash=sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b \
@@ -288,7 +230,6 @@ pyyaml==6.0 \
     # via
     #   -c requirements/main.txt
     #   pre-commit
-    #   uvicorn
 rfc3986[idna2008]==1.5.0 \
     --hash=sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835 \
     --hash=sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97
@@ -325,91 +266,7 @@ typing-extensions==4.1.1 \
     # via
     #   -c requirements/main.txt
     #   mypy
-uvicorn[standard]==0.17.6 \
-    --hash=sha256:19e2a0e96c9ac5581c01eb1a79a7d2f72bb479691acd2b8921fce48ed5b961a6 \
-    --hash=sha256:5180f9d059611747d841a4a4c4ab675edf54c8489e97f96d0583ee90ac3bfc23
-    # via
-    #   -c requirements/main.txt
-    #   -r requirements/dev.in
-uvloop==0.16.0 \
-    --hash=sha256:04ff57aa137230d8cc968f03481176041ae789308b4d5079118331ab01112450 \
-    --hash=sha256:089b4834fd299d82d83a25e3335372f12117a7d38525217c2258e9b9f4578897 \
-    --hash=sha256:1e5f2e2ff51aefe6c19ee98af12b4ae61f5be456cd24396953244a30880ad861 \
-    --hash=sha256:30ba9dcbd0965f5c812b7c2112a1ddf60cf904c1c160f398e7eed3a6b82dcd9c \
-    --hash=sha256:3a19828c4f15687675ea912cc28bbcb48e9bb907c801873bd1519b96b04fb805 \
-    --hash=sha256:6224f1401025b748ffecb7a6e2652b17768f30b1a6a3f7b44660e5b5b690b12d \
-    --hash=sha256:647e481940379eebd314c00440314c81ea547aa636056f554d491e40503c8464 \
-    --hash=sha256:6ccd57ae8db17d677e9e06192e9c9ec4bd2066b77790f9aa7dede2cc4008ee8f \
-    --hash=sha256:772206116b9b57cd625c8a88f2413df2fcfd0b496eb188b82a43bed7af2c2ec9 \
-    --hash=sha256:8e0d26fa5875d43ddbb0d9d79a447d2ace4180d9e3239788208527c4784f7cab \
-    --hash=sha256:98d117332cc9e5ea8dfdc2b28b0a23f60370d02e1395f88f40d1effd2cb86c4f \
-    --hash=sha256:b572256409f194521a9895aef274cea88731d14732343da3ecdb175228881638 \
-    --hash=sha256:bd53f7f5db562f37cd64a3af5012df8cac2c464c97e732ed556800129505bd64 \
-    --hash=sha256:bd8f42ea1ea8f4e84d265769089964ddda95eb2bb38b5cbe26712b0616c3edee \
-    --hash=sha256:e814ac2c6f9daf4c36eb8e85266859f42174a4ff0d71b99405ed559257750382 \
-    --hash=sha256:f74bc20c7b67d1c27c72601c78cf95be99d5c2cdd4514502b4f3eb0933ff1228
-    # via
-    #   -c requirements/main.txt
-    #   uvicorn
 virtualenv==20.13.4 \
     --hash=sha256:c3e01300fb8495bc00ed70741f5271fc95fed067eb7106297be73d30879af60c \
     --hash=sha256:ce8901d3bbf3b90393498187f2d56797a8a452fb2d0d7efc6fd837554d6f679c
     # via pre-commit
-watchgod==0.8 \
-    --hash=sha256:29a1d8f25e1721ddb73981652ca318c47387ffb12ec4171ddd7b9d01540033b1 \
-    --hash=sha256:339c2cfede1ccc1e277bbf5e82e42886f3c80801b01f45ab10d9461c4118b5eb
-    # via
-    #   -c requirements/main.txt
-    #   uvicorn
-websockets==10.2 \
-    --hash=sha256:038afef2a05893578d10dadbdbb5f112bd115c46347e1efe99f6a356ff062138 \
-    --hash=sha256:05f6e9757017270e7a92a2975e2ae88a9a582ffc4629086fd6039aa80e99cd86 \
-    --hash=sha256:0b66421f9f13d4df60cd48ab977ed2c2b6c9147ae1a33caf5a9f46294422fda1 \
-    --hash=sha256:0cd02f36d37e503aca88ab23cc0a1a0e92a263d37acf6331521eb38040dcf77b \
-    --hash=sha256:0f73cb2526d6da268e86977b2c4b58f2195994e53070fe567d5487c6436047e6 \
-    --hash=sha256:117383d0a17a0dda349f7a8790763dde75c1508ff8e4d6e8328b898b7df48397 \
-    --hash=sha256:1c1f3b18c8162e3b09761d0c6a0305fd642934202541cc511ef972cb9463261e \
-    --hash=sha256:1c9031e90ebfc486e9cdad532b94004ade3aa39a31d3c46c105bb0b579cd2490 \
-    --hash=sha256:2349fa81b6b959484bb2bda556ccb9eb70ba68987646a0f8a537a1a18319fb03 \
-    --hash=sha256:24b879ba7db12bb525d4e58089fcbe6a3df3ce4666523183654170e86d372cbe \
-    --hash=sha256:2aa9b91347ecd0412683f28aabe27f6bad502d89bd363b76e0a3508b1596402e \
-    --hash=sha256:56d48eebe9e39ce0d68701bce3b21df923aa05dcc00f9fd8300de1df31a7c07c \
-    --hash=sha256:5a38a0175ae82e4a8c4bac29fc01b9ee26d7d5a614e5ee11e7813c68a7d938ce \
-    --hash=sha256:5b04270b5613f245ec84bb2c6a482a9d009aefad37c0575f6cda8499125d5d5c \
-    --hash=sha256:6193bbc1ee63aadeb9a4d81de0e19477401d150d506aee772d8380943f118186 \
-    --hash=sha256:669e54228a4d9457abafed27cbf0e2b9f401445c4dfefc12bf8e4db9751703b8 \
-    --hash=sha256:6a009eb551c46fd79737791c0c833fc0e5b56bcd1c3057498b262d660b92e9cd \
-    --hash=sha256:71a4491cfe7a9f18ee57d41163cb6a8a3fa591e0f0564ca8b0ed86b2a30cced4 \
-    --hash=sha256:7b38a5c9112e3dbbe45540f7b60c5204f49b3cb501b40950d6ab34cd202ab1d0 \
-    --hash=sha256:7bb9d8a6beca478c7e9bdde0159bd810cc1006ad6a7cb460533bae39da692ca2 \
-    --hash=sha256:82bc33db6d8309dc27a3bee11f7da2288ad925fcbabc2a4bb78f7e9c56249baf \
-    --hash=sha256:8351c3c86b08156337b0e4ece0e3c5ec3e01fcd14e8950996832a23c99416098 \
-    --hash=sha256:8beac786a388bb99a66c3be4ab0fb38273c0e3bc17f612a4e0a47c4fc8b9c045 \
-    --hash=sha256:97950c7c844ec6f8d292440953ae18b99e3a6a09885e09d20d5e7ecd9b914cf8 \
-    --hash=sha256:98f57b3120f8331cd7440dbe0e776474f5e3632fdaa474af1f6b754955a47d71 \
-    --hash=sha256:9ca2ca05a4c29179f06cf6727b45dba5d228da62623ec9df4184413d8aae6cb9 \
-    --hash=sha256:a03a25d95cc7400bd4d61a63460b5d85a7761c12075ee2f51de1ffe73aa593d3 \
-    --hash=sha256:a10c0c1ee02164246f90053273a42d72a3b2452a7e7486fdae781138cf7fbe2d \
-    --hash=sha256:a72b92f96e5e540d5dda99ee3346e199ade8df63152fa3c737260da1730c411f \
-    --hash=sha256:ac081aa0307f263d63c5ff0727935c736c8dad51ddf2dc9f5d0c4759842aefaa \
-    --hash=sha256:b22bdc795e62e71118b63e14a08bacfa4f262fd2877de7e5b950f5ac16b0348f \
-    --hash=sha256:b4059e2ccbe6587b6dc9a01db5fc49ead9a884faa4076eea96c5ec62cb32f42a \
-    --hash=sha256:b7fe45ae43ac814beb8ca09d6995b56800676f2cfa8e23f42839dc69bba34a42 \
-    --hash=sha256:bef03a51f9657fb03d8da6ccd233fe96e04101a852f0ffd35f5b725b28221ff3 \
-    --hash=sha256:bffc65442dd35c473ca9790a3fa3ba06396102a950794f536783f4b8060af8dd \
-    --hash=sha256:c21a67ab9a94bd53e10bba21912556027fea944648a09e6508415ad14e37c325 \
-    --hash=sha256:c67d9cacb3f6537ca21e9b224d4fd08481538e43bcac08b3d93181b0816def39 \
-    --hash=sha256:c6e56606842bb24e16e36ae7eb308d866b4249cf0be8f63b212f287eeb76b124 \
-    --hash=sha256:cb316b87cbe3c0791c2ad92a5a36bf6adc87c457654335810b25048c1daa6fd5 \
-    --hash=sha256:cef40a1b183dcf39d23b392e9dd1d9b07ab9c46aadf294fff1350fb79146e72b \
-    --hash=sha256:cf931c33db9c87c53d009856045dd524e4a378445693382a920fa1e0eb77c36c \
-    --hash=sha256:d4d110a84b63c5cfdd22485acc97b8b919aefeecd6300c0c9d551e055b9a88ea \
-    --hash=sha256:d5396710f86a306cf52f87fd8ea594a0e894ba0cc5a36059eaca3a477dc332aa \
-    --hash=sha256:f09f46b1ff6d09b01c7816c50bd1903cf7d02ebbdb63726132717c2fcda835d5 \
-    --hash=sha256:f14bd10e170abc01682a9f8b28b16e6f20acf6175945ef38db6ffe31b0c72c3f \
-    --hash=sha256:f5c335dc0e7dc271ef36df3f439868b3c790775f345338c2f61a562f1074187b \
-    --hash=sha256:f8296b8408ec6853b26771599990721a26403e62b9de7e50ac0a056772ac0b5e \
-    --hash=sha256:fa35c5d1830d0fb7b810324e9eeab9aa92e8f273f11fdbdc0741dcded6d72b9f
-    # via
-    #   -c requirements/main.txt
-    #   uvicorn

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -7,7 +7,6 @@
 
 # These dependencies are for fastapi including some optional features.
 fastapi
-gunicorn
 starlette
 uvicorn[standard]
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -35,10 +35,6 @@ fastapi==0.75.0 \
     # via
     #   -r requirements/main.in
     #   safir
-gunicorn==20.1.0 \
-    --hash=sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e \
-    --hash=sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8
-    # via -r requirements/main.in
 h11==0.12.0 \
     --hash=sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6 \
     --hash=sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042
@@ -225,9 +221,9 @@ uvloop==0.16.0 \
     --hash=sha256:e814ac2c6f9daf4c36eb8e85266859f42174a4ff0d71b99405ed559257750382 \
     --hash=sha256:f74bc20c7b67d1c27c72601c78cf95be99d5c2cdd4514502b4f3eb0933ff1228
     # via uvicorn
-watchgod==0.8 \
-    --hash=sha256:29a1d8f25e1721ddb73981652ca318c47387ffb12ec4171ddd7b9d01540033b1 \
-    --hash=sha256:339c2cfede1ccc1e277bbf5e82e42886f3c80801b01f45ab10d9461c4118b5eb
+watchgod==0.8.1 \
+    --hash=sha256:4ba20c2fa3e63df706ab50e694b9453b05395fadb7cbbfd984d71fb1547d485d \
+    --hash=sha256:c12d15f3df7d11e740704e45398277f75f1d78f46ad59ca9d7505bfd8b8d3086
     # via uvicorn
 websockets==10.2 \
     --hash=sha256:038afef2a05893578d10dadbdbb5f112bd115c46347e1efe99f6a356ff062138 \
@@ -279,7 +275,3 @@ websockets==10.2 \
     --hash=sha256:f8296b8408ec6853b26771599990721a26403e62b9de7e50ac0a056772ac0b5e \
     --hash=sha256:fa35c5d1830d0fb7b810324e9eeab9aa92e8f273f11fdbdc0741dcded6d72b9f
     # via uvicorn
-
-# WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,12 +3,11 @@ name = safirdemo
 description = Demo of the Safir framework for Roundtable services.
 author = Association of Universities for Research in Astronomy, Inc. (AURA)
 author_email = sqre-admin@lists.lsst.org
-long_description = file: README.rst, CHANGELOG.rst, LICENSE
+long_description = file: README.rst, LICENSE
 long_description_content_type = text/x-rst
 license = MIT
 url = https://github.com/lsst-sqre/safirdemo
 project_urls =
-    Change log = https://github.com/lsst-sqre/safirdemo/master/blob/CHANGELOG.rst
     Source code = https://github.com/lsst-sqre/safirdemo
     Issue tracker = https://github.com/lsst-sqre/safirdemo/issues
 classifiers =
@@ -16,8 +15,8 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Natural Language :: English
     Operating System :: POSIX
 keywords =
@@ -29,7 +28,7 @@ include_package_data = True
 package_dir =
     = src
 packages=find:
-python_requires = >=3.8
+python_requires = >=3.9
 setup_requires =
     setuptools_scm
 # Use requirements/main.in for runtime dependencies instead of install_requires

--- a/src/safirdemo/handlers/external.py
+++ b/src/safirdemo/handlers/external.py
@@ -32,7 +32,7 @@ async def get_index(
     Customize this handler to return whatever the top-level resource of your
     application should return. For example, consider listing key API URLs.
     When doing so, also change or customize the response model in
-    safirdemo.models.metadata.
+    `safirdemo.models.Index`.
 
     By convention, the root of the external API includes a field called
     ``metadata`` that provides the same Safir-generated metadata as the

--- a/src/safirdemo/handlers/internal.py
+++ b/src/safirdemo/handlers/internal.py
@@ -26,6 +26,7 @@ internal_router = APIRouter()
         " a health check. This route is not exposed outside the cluster and"
         " therefore cannot be used by external clients."
     ),
+    include_in_schema=False,
     response_model=Metadata,
     response_model_exclude_none=True,
     summary="Application metadata",

--- a/src/safirdemo/main.py
+++ b/src/safirdemo/main.py
@@ -27,21 +27,19 @@ configure_logging(
     name=config.logger_name,
 )
 
-app = FastAPI()
+app = FastAPI(
+    title="safirdemo",
+    description=metadata("safirdemo").get("Summary", ""),
+    version=metadata("safirdemo").get("Version", "0.0.0"),
+    openapi_url=f"/{config.name}/openapi.json",
+    docs_url=f"/{config.name}/docs",
+    redoc_url=f"/{config.name}/redoc",
+)
 """The main FastAPI application for safirdemo."""
 
-# Define the external routes in a subapp so that it will serve its own OpenAPI
-# interface definition and documentation URLs under the external URL.
-_subapp = FastAPI(
-    title="safirdemo",
-    description="Demo of the Safir framework for Roundtable services",
-    version=metadata("safirdemo").get("Version", "0.0.0"),
-)
-_subapp.include_router(external_router)
-
-# Attach the internal routes and subapp to the main application.
+# Attach the routers.
 app.include_router(internal_router)
-app.mount(f"/{config.name}", _subapp)
+app.include_router(external_router, prefix=f"/{config.name}")
 
 
 @app.on_event("startup")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,21 +2,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import AsyncIterator
 
-import pytest
+import pytest_asyncio
 from asgi_lifespan import LifespanManager
+from fastapi import FastAPI
 from httpx import AsyncClient
 
 from safirdemo import main
 
-if TYPE_CHECKING:
-    from typing import AsyncIterator
 
-    from fastapi import FastAPI
-
-
-@pytest.fixture
+@pytest_asyncio.fixture
 async def app() -> AsyncIterator[FastAPI]:
     """Return a configured test application.
 
@@ -27,7 +23,7 @@ async def app() -> AsyncIterator[FastAPI]:
         yield main.app
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
     async with AsyncClient(app=app, base_url="https://example.com/") as client:

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
+from httpx import AsyncClient
 
 from safirdemo.config import config
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/internal_test.py
+++ b/tests/handlers/internal_test.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
+from httpx import AsyncClient
 
 from safirdemo.config import config
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This is an almost-exact replica of what comes out of the current
fastapi_safir_app template.  The only changes made to the files
generated by the template were to restore the previous README.rst
and to update the version number in kustomization.yaml.